### PR TITLE
Don't limit the arch to amd64

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -6,8 +6,6 @@ base: core22
 issues: https://github.com/ubuntu/drawing/issues
 contact: https://github.com/ubuntu/drawing
 website: https://maoschanz.github.io/drawing
-architectures:
-  - build-on: amd64
 
 layout:
   /usr/share/drawing:


### PR DESCRIPTION
Don't limit the arch to amd64, we can configure launchpad to build for specific architectures.
